### PR TITLE
Fix writing zero-terminated buffer

### DIFF
--- a/lib/smart-buffer.js
+++ b/lib/smart-buffer.js
@@ -283,11 +283,8 @@ var SmartBuffer = (function () {
      * @returns {*}
      */
     SmartBuffer.prototype.writeBufferNT = function (value, offset) {
-        var len = value.length;
-        this._ensureWritable(len, offset);
-        value.copy(this.buff, typeof offset === 'number' ? offset : this._writeOffset);
-        this.buff[(typeof offset === 'number' ? offset : this._writeOffset) + len] = 0x00;
-        this._writeOffset += len + 1;
+        this.writeBuffer(value, offset);
+        this.writeUInt8(0x00);
         return this;
     };
 


### PR DESCRIPTION
`writeBufferNT` doesn't allocate a space for null byte; moreover it duplicates code.
Code to check the bug:
```
var smb = new smbuf(1);
console.log(smb);
smb.writeBufferNT(Buffer.from('aaa'));
console.log(smb);
```
```
>arr.njs
SmartBuffer { buff: <Buffer 00>, length: 0, _readOffset: 0, _writeOffset: 0 }
SmartBuffer {
  buff: <Buffer 61 61 61>,
  length: 3,
  _readOffset: 0,
  _writeOffset: 4 }
```