### PR TITLE
Special case `readString` when the length is equals to 0

### DIFF
--- a/src/smartbuffer.ts
+++ b/src/smartbuffer.ts
@@ -477,7 +477,7 @@ class SmartBuffer {
      * @return { String }
      */
     readString(length?: number, encoding?: BufferEncoding): string {
-        const lengthVal = Math.min(length, this.length - this.readOffset) || this.length - this.readOffset;
+        const lengthVal = (typeof length === 'number') ? Math.min(length, this.length - this.readOffset) : this.length - this.readOffset;
         const value = this.buff.slice(this.readOffset, this.readOffset + lengthVal).toString(encoding || this.encoding);
 
         this.readOffset += lengthVal;

--- a/test/smartbuffer.test.js
+++ b/test/smartbuffer.test.js
@@ -280,6 +280,10 @@ describe('Reading/Writing To/From SmartBuffer', function () {
             assert.strictEqual(reader.readStringNT().length, 0);
         });
 
+        it('should return an empty string', function () {
+            assert.strictEqual(reader.readString(0), '');
+        });
+
         it('should equal: bleh', function () {
             assert.strictEqual(reader.readStringNT(), 'bleh');
         });


### PR DESCRIPTION
When the `readString` length parameter is equal to 0, this one is considered as a null value and the function reads until the end and I think this is not the correct behavior.