### PR TITLE
Add `readSkip` and `writeSkip` methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,6 +564,38 @@ buff.writeOffset = 10;
 console.log(buff.writeOffset) // 10
 ```
 
+### buff.readSkip(length)
+- ```length``` *{number}* The length of data to skip.
+
+Skips reading for a specified `length` from the current read offset.
+
+This method is just sugar for incrementing the read offset in a chainable way.
+
+Examples:
+```javascript
+buff.readOffset = 5;
+
+buff.readSkip(10).readString(4);
+
+console.log(buff.readOffset) // 19
+```
+
+### buff.writeSkip(length)
+- ```length``` *{number}* The length of data to skip.
+
+Skips writing for a specified `length` from the current write offset. The buffer will be zero-padded for the skipped range.
+
+This method is just sugar for incrementing the write offset in a chainable way.
+
+Examples:
+```javascript
+buff.writeOffset = 5;
+
+buff.writeSkip(10).writeString('cool');
+
+console.log(buff.writeOffset) // 19
+```
+
 ### buff.encoding
 ### buff.encoding(encoding)
 - ```encoding``` *{string}* The new string encoding to set.

--- a/src/smartbuffer.ts
+++ b/src/smartbuffer.ts
@@ -999,6 +999,37 @@ class SmartBuffer {
   }
 
   /**
+   * Skips reading for a specified `length` from the current read position.
+   *
+   * This method is just sugar for incrementing the read offset in a chainable way.
+   *
+   * @param length { Number } The length of data to skip.
+   *
+   * @return this
+   */
+  readSkip(length: number): SmartBuffer {
+    checkLengthValue(length);
+    this.readOffset += length;
+    return this;
+  }
+
+  /**
+   * Skips writing for a specified `length` from the current write position.
+   * The buffer will be zero-padded for the skipped range.
+   *
+   * This method is just sugar for incrementing the write offset in a chainable way.
+   *
+   * @param length { Number } The length of data to skip.
+   *
+   * @return this
+   */
+  writeSkip(length: number): SmartBuffer {
+    checkLengthValue(length);
+    this.writeBuffer(Buffer.alloc(length));
+    return this;
+  }
+
+  /**
    * Clears the SmartBuffer instance to its original empty state.
    */
   clear(): SmartBuffer {


### PR DESCRIPTION
This PR adds convenience methods for skipping when reading/writing.

Resolves #46.